### PR TITLE
feat(ERP-315): adiciona novos atributos e getters em FindInvoiceResponse

### DIFF
--- a/src/Api/Invoice/FindInvoiceResponse.php
+++ b/src/Api/Invoice/FindInvoiceResponse.php
@@ -79,6 +79,15 @@ class FindInvoiceResponse extends InvoiceResponse
     protected ?string $transaction_number;
     protected ?string $payment_method;
     protected ?string $financial_return_dates;
+    protected ?int $per_day_interest_cents = null;
+    protected ?int $bank_slip_extra_due = null;
+    protected ?int $overpaid_cents = null;
+    /** @var string[] $early_payment_discounts */
+    protected array $early_payment_discounts = [];
+    protected ?string $order_id = null;
+    protected ?string $subscription_id = null;
+    /** @var string[] $split_rules */
+    protected ?array $split_rules = null;
 
     public function getTotalPaidCents(): ?string
     {
@@ -453,5 +462,70 @@ class FindInvoiceResponse extends InvoiceResponse
     public function getFinancialReturnDates(): ?string
     {
         return $this->financial_return_dates;
+    }
+
+    /**
+     * Valor dos juros por dia em centavos, calculado com base na data de vencimento.
+     * Corresponde ao campo `per_day_interest_value` (%) aplicado sobre o valor da fatura.
+     * Retorna 0 quando a fatura não está vencida.
+     */
+    public function getPerDayInterestCents(): ?int
+    {
+        return $this->per_day_interest_cents;
+    }
+
+    /**
+     * Número de dias extras de tolerância após o vencimento durante os quais
+     * o boleto ainda pode ser pago em qualquer banco.
+     */
+    public function getBankSlipExtraDue(): ?int
+    {
+        return $this->bank_slip_extra_due;
+    }
+
+    /**
+     * Valor pago a mais (overpayment) em centavos.
+     * Presente quando o pagamento foi maior que o total da fatura.
+     */
+    public function getOverpaidCents(): ?int
+    {
+        return $this->overpaid_cents;
+    }
+
+    /**
+     * Lista de descontos configurados para pagamento antecipado.
+     * Cada item contém `days` (dias antes do vencimento) e `value_cents` (valor do desconto em centavos).
+     */
+    public function getEarlyPaymentDiscounts(): array
+    {
+        return $this->early_payment_discounts;
+    }
+
+    /**
+     * Identificador externo da ordem vinculada à fatura.
+     * Definido no momento da criação via `order_id`.
+     */
+    public function getOrderId(): ?string
+    {
+        return $this->order_id;
+    }
+
+    /**
+     * ID da assinatura recorrente à qual esta fatura pertence.
+     * Presente apenas em faturas geradas automaticamente por uma assinatura.
+     */
+    public function getSubscriptionId(): ?string
+    {
+        return $this->subscription_id;
+    }
+
+    /**
+     * Regras de split (divisão de recebimento) configuradas para esta fatura.
+     * Cada item define um destinatário e o valor ou percentual que receberá.
+     * Retorna null quando não há split configurado.
+     */
+    public function getSplitRules(): ?array
+    {
+        return $this->split_rules;
     }
 }

--- a/tests/Feature/InvoiceApiTest.php
+++ b/tests/Feature/InvoiceApiTest.php
@@ -3,6 +3,7 @@
 namespace Jetimob\Iugu\Tests\Feature;
 
 use Carbon\Carbon;
+use Jetimob\Iugu\Api\Invoice\FindInvoiceResponse;
 use Jetimob\Iugu\Api\Invoice\InvoiceApi;
 use Jetimob\Iugu\Entity\Address;
 use Jetimob\Iugu\Entity\Invoice;
@@ -80,6 +81,40 @@ class InvoiceApiTest extends AbstractTestCase
 
         $this->assertSame(200, $res->getStatusCode());
         $this->assertSame($invoiceId, $res->getId());
+    }
+
+    /** @test */
+    public function findInvoiceResponseShouldHydrateNewFields(): void
+    {
+        $payload = json_encode([
+            'early_payment_discounts' => [
+                ['days' => 10, 'value_cents' => 500],
+                ['days' => 5,  'value_cents' => 200],
+            ],
+            'split_rules' => [
+                ['recipient_account_id' => 'abc123', 'cents' => 1000],
+            ],
+            'per_day_interest_cents' => 150,
+            'bank_slip_extra_due'    => 3,
+            'overpaid_cents'         => 0,
+            'order_id'               => 'ORD-001',
+            'subscription_id'        => 'SUB-999',
+        ]);
+
+        $response = FindInvoiceResponse::deserialize($payload);
+
+        $this->assertCount(2, $response->getEarlyPaymentDiscounts());
+        $this->assertSame(10, $response->getEarlyPaymentDiscounts()[0]['days']);
+
+        $this->assertIsArray($response->getSplitRules());
+        $this->assertCount(1, $response->getSplitRules());
+        $this->assertSame('abc123', $response->getSplitRules()[0]['recipient_account_id']);
+
+        $this->assertSame(150, $response->getPerDayInterestCents());
+        $this->assertSame(3,   $response->getBankSlipExtraDue());
+        $this->assertSame(0,   $response->getOverpaidCents());
+        $this->assertSame('ORD-001', $response->getOrderId());
+        $this->assertSame('SUB-999', $response->getSubscriptionId());
     }
 
     protected function createGenericInvoice(): Invoice


### PR DESCRIPTION
---

# Descrição do PR
Adição de novos campos para consultas na fatura 

---

- **Link da task no Jira:** [ERP-315](https://jetimob.jetimob.com/browse/ERP-315)
- **Contexto:** Adicionado novos campos na classe `FindInvoiceResponse`   retornados pela API da Iugu na consulta de faturas. 
- Campos como `per_day_interest_cents`, `bank_slip_extra_due`, `overpaid_cents`, `early_payment_discounts`, `order_id`, `subscription_id` e `split_rules` estavam ausentes, impossibilitando seu uso via SDK. Adição baseada na [documentação oficial](https://dev.iugu.com/docs/faturas-1).

- **O que foi feito:**
  - Adicionados 7 novos atributos em `FindInvoiceResponse`: `per_day_interest_cents`, `bank_slip_extra_due`, `overpaid_cents`, `early_payment_discounts`, `order_id`, `subscription_id` e `split_rules`

  - Adicionados getters correspondentes para cada novo atributo, com docblocks explicando o comportamento de cada campo

  - Adicionado teste unitário `findInvoiceResponseShouldHydrateNewFields` cobrindo a hidratação de todos os novos campos via `FindInvoiceResponse::deserialize()`

---

# Como testar

_Passos para validar a alteração_

Executar o teste adicionado: 

```
./vendor/bin/phpunit --filter findInvoiceResponseShouldHydrateNewFields
```
---

# Evidências
<img width="1124" height="208" alt="Captura de tela de 2026-03-20 11-41-16" src="https://github.com/user-attachments/assets/e7297cc2-d1fa-4f02-87ba-bb9feeb7954b" />

---


