### PR TITLE
feat(ERP-315): adiciona atributo fine_cents e getter em FindInvoiceResponse

### DIFF
--- a/src/Api/Invoice/FindInvoiceResponse.php
+++ b/src/Api/Invoice/FindInvoiceResponse.php
@@ -88,6 +88,7 @@ class FindInvoiceResponse extends InvoiceResponse
     protected ?string $subscription_id = null;
     /** @var string[] $split_rules */
     protected ?array $split_rules = null;
+    protected ?string $fine_cents;
 
     public function getTotalPaidCents(): ?string
     {
@@ -527,5 +528,14 @@ class FindInvoiceResponse extends InvoiceResponse
     public function getSplitRules(): ?array
     {
         return $this->split_rules;
+    }
+
+    /**
+     * Valor da multa em centavos calculado
+     * Retorna null quando não há multa aplicável
+     */
+    public function getFineCents(): ?string
+    {
+        return $this->fine_cents;
     }
 }


### PR DESCRIPTION
---

# Descrição do PR
_Adiciona suporte ao campo `fine_cents` na resposta detalhada de faturas da API Iugu._

---

- **Link da task no Jira:** [ERP-315](https://jetimob.jetimob.com/browse/ERP-315)
- **Contexto:** A API da Iugu retorna o campo `fine_cents` (valor da multa em centavos) no endpoint de busca detalhada de faturas, mas este valor não estava sendo mapeado para a classe `FindInvoiceResponse`, impedindo o acesso programático a essa informação.
- **O que foi feito:**
  - Adicionado atributo `protected ?string $fine_cents` na classe `FindInvoiceResponse`
  - Implementado getter `getFineCents(): ?string` 
---

# Como testar
_Passos para validar a alteração_
1. Criar uma fatura via API com configuração de multa por atraso
2. Aguardar vencimento ou simular pagamento com multa aplicada
4. Verificar se `getFineCents()` retorna o valor correto em centavos

---
